### PR TITLE
feat: add INS orientations for autoware_orientaiton_msg

### DIFF
--- a/clap_b7_driver/include/clap_b7_driver/clap_msg_wrapper.h
+++ b/clap_b7_driver/include/clap_b7_driver/clap_msg_wrapper.h
@@ -67,7 +67,7 @@ namespace clap_b7{
 
         sensor_msgs::msg::Temperature create_temperature_msg(const RawImu &raw_imu, std::string frame_id) const;
 
-        autoware_sensing_msgs::msg::GnssInsOrientationStamped create_autoware_orientation_msg(const InsPvax &ins, const UniHeading& heading, std::string frame_id) const;
+        autoware_sensing_msgs::msg::GnssInsOrientationStamped create_autoware_orientation_msg(const InsPvax &ins, std::string frame_id) const;
         static double add_heading_offset(double heading, double offset);
 
         geometry_msgs::msg::TransformStamped

--- a/clap_b7_driver/src/clap_b7_driver.cpp
+++ b/clap_b7_driver/src/clap_b7_driver.cpp
@@ -172,7 +172,7 @@ namespace clap_b7{
                     auto msg = msg_wrapper_.create_sensor_imu_msg(raw_imu_, ins_pvax_, params_.get_imu_frame());
                     publishers_.publish_imu(msg);
 
-                    auto autoware_msg = msg_wrapper_.create_autoware_orientation_msg(ins_pvax_, heading_, params_.get_gnss_frame());
+                    auto autoware_msg = msg_wrapper_.create_autoware_orientation_msg(ins_pvax_, params_.get_gnss_frame());
                     publishers_.publish_autoware_orientation(autoware_msg);
                 }
 

--- a/clap_b7_driver/src/clap_msg_wrapper.cpp
+++ b/clap_b7_driver/src/clap_msg_wrapper.cpp
@@ -533,7 +533,7 @@ namespace clap_b7{
         return wheel_odom_msg;
     }
 
-    autoware_sensing_msgs::msg::GnssInsOrientationStamped ClapMsgWrapper::create_autoware_orientation_msg(const InsPvax &ins, const UniHeading& heading, std::string frame_id) const {
+    autoware_sensing_msgs::msg::GnssInsOrientationStamped ClapMsgWrapper::create_autoware_orientation_msg(const InsPvax &ins, std::string frame_id) const {
         autoware_sensing_msgs::msg::GnssInsOrientationStamped orientation_msg;
         orientation_msg.header = create_header(std::move(frame_id));
         tf2::Quaternion q;
@@ -542,7 +542,7 @@ namespace clap_b7{
         * in clap b7 roll-> y-axis pitch-> x axis azimuth->left-handed rotation around z-axis
         * in ros imu msg roll-> x-axis pitch-> y axis azimuth->right-handed rotation around z-axis
         */
-        q.setRPY(degree2radian(heading.pitch), degree2radian(ins.roll), degree2radian(-heading.heading));
+        q.setRPY(degree2radian(ins.pitch), degree2radian(ins.roll), degree2radian(-ins.azimuth));
 
         orientation_msg.orientation.orientation.x = q.x();
         orientation_msg.orientation.orientation.y = q.y();
@@ -550,9 +550,9 @@ namespace clap_b7{
         orientation_msg.orientation.orientation.w = q.w();
 
 
-        orientation_msg.orientation.rmse_rotation_x = heading.std_dev_pitch * heading.std_dev_pitch;
+        orientation_msg.orientation.rmse_rotation_x = ins.std_dev_pitch * ins.std_dev_pitch;
         orientation_msg.orientation.rmse_rotation_y = ins.std_dev_roll * ins.std_dev_roll;
-        orientation_msg.orientation.rmse_rotation_z = heading.std_dev_heading * heading.std_dev_heading;
+        orientation_msg.orientation.rmse_rotation_z = ins.std_dev_azimuth * ins.std_dev_azimuth;
 
         return orientation_msg;
     }


### PR DESCRIPTION
## Description

This PR changes autoware orientation messages source to INS instead of GNSS:

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
